### PR TITLE
Add quick comment/suggest bubble CSS

### DIFF
--- a/dark-docs.css
+++ b/dark-docs.css
@@ -5,6 +5,7 @@
   --ripple: #394457;
   --gray: #3C4043;
   --darkgray: #202124;
+  --lightgray: #666;
   --text-hover-on: text-shadow 0.1s ease;
   --text-hover-off: text-shadow 0.25s ease;
   --button-on: background-color 0.1s ease;
@@ -497,4 +498,24 @@
 }
 .companion-guest-app-switcher .app-switcher-button-selected .app-switcher-button-icon-background-inner {
   background-color: var(--ripple);
+}
+
+/* Quick comment/suggest bubble */
+#docs-instant-bubble {
+  --gray-rgb: 60, 64, 67;
+  border-color: var(--gray);
+  background: rgba(var(--gray-rgb),0.5);
+  transition: var(--button-off);
+}
+#docs-instant-bubble:hover {
+  background: rgba(var(--gray-rgb),0.7);
+  transition: var(--button-on);
+}
+
+#docs-instant-bubble .instant-button {
+  transition: var(--button-off);
+}
+#docs-instant-bubble .instant-button:hover {
+  background: var(--lightgray);
+  transition: var(--button-on);
 }


### PR DESCRIPTION
Added dark mode styles for the bubble with commenting and/or suggesting prompts that appears when one hovers along the side of the document. 
I based the colours off of what I deem to look alright. The README does state that the current colours are based off those in the mobile app; however, given that one cannot "hover" on mobile devices, I did not use said guideline for this element. 

I have only tested this on Firefox v92.0, but the CSS properties used *should* be compatible on modern browsers. 