### PR TITLE
Add (more) popup styles

### DIFF
--- a/dark-docs.css
+++ b/dark-docs.css
@@ -421,6 +421,36 @@ body {
   transition: var(--button-on);
 }
 
+/* Link popup */
+
+.docs-gm .docs-linkbubble-bubble,
+.docs-gm .docs-multi-linkbubble-bubble {
+  background-color: var(--darkgray);
+  border: 1px solid var(--lightgray) !important;
+}
+#docs-linkbubble-link-text {
+  color: var(--paleblue) !important;
+}
+.docs-bubble .docs-bubble-button.jfk-button:hover, 
+.docs-bubble .docs-bubble-button.jfk-button:focus {
+  background-color: var(--gray);
+  transition: var(--button-on);
+}
+/* Link popup footer that prompts to replace the link */
+.docs-linkbubble-link-preview .docs-link-bubble-card-component.docs-link-bubble-action-card-component, 
+.docs-linkbubble-link-preview .docs-link-bubble-action-card-component::before {
+  background-color: #1967d24a !important;
+}
+#docs-link-bubble .docs-link-bubble-card-component.docs-link-bubble-action-card-component .link-bubble-text-button-text:hover {
+  background-color: #4689e34d !important;
+}
+.docs-linkbubble-link-preview .docs-link-bubble-text-card-component span,
+.docs-linkbubble-link-preview .docs-link-bubble-action-card-component span,
+.text-card-component-text.docs-link-bubble-text-with-icon,
+.docs-link-bubble-card-component.docs-link-bubble-action-card-component .link-bubble-text-button-text {
+  color: var(--lightergray) !important;
+}
+
 /* Table border editing */
 .docs-border-selection-button-pressed, 
 .docs-border-selection-button-normal {

--- a/dark-docs.css
+++ b/dark-docs.css
@@ -445,10 +445,7 @@ body {
 #docs-link-bubble .docs-link-bubble-card-component.docs-link-bubble-action-card-component .link-bubble-text-button-text:hover {
   background-color: #4689e34d !important;
 }
-.docs-linkbubble-link-preview .docs-link-bubble-text-card-component span,
-.docs-linkbubble-link-preview .docs-link-bubble-action-card-component span,
-.text-card-component-text.docs-link-bubble-text-with-icon,
-.docs-link-bubble-card-component.docs-link-bubble-action-card-component .link-bubble-text-button-text {
+.docs-linkbubble-link-preview .docs-link-bubble-text-card-component span {
   color: var(--lightergray) !important;
 }
 

--- a/dark-docs.css
+++ b/dark-docs.css
@@ -399,19 +399,20 @@ body {
   filter: invert(100%) hue-rotate(180deg) contrast(80%);
 }
 
-/* Spellcheck mini popup */
-.docs-gm .kix-spell-bubble, .docs-autocorrect-bubble {
+/* Popups */
+
+/* Box */
+.docs-gm .kix-spell-bubble, 
+.docs-autocorrect-bubble,
+.docs-gm .docs-linkbubble-bubble, 
+.docs-gm .docs-multi-linkbubble-bubble {
   background-color: var(--darkgray);
   border: 1px solid var(--lightgray) !important;
 }
-.docs-autocorrect-bubble .docs-autocorrect-bubble-undo,
-.kix-spell-bubble .kix-spell-bubble-suggestion-text {
-  color: white;
-}
-.docs-gm .kix-spell-bubble-option {
-  border-radius: 50%;
-  transition: var(--button-off);
-}
+
+/* Popup options */
+.docs-bubble .docs-bubble-button.jfk-button:hover, 
+.docs-bubble .docs-bubble-button.jfk-button:focus,
 .docs-gm .docs-autocorrect-bubble-more-options:hover,
 .docs-gm .docs-autocorrect-bubble-more-options:focus,
 .docs-gm .docs-autocorrect-bubble-undo:hover,
@@ -421,20 +422,19 @@ body {
   transition: var(--button-on);
 }
 
-/* Link popup */
-
-.docs-gm .docs-linkbubble-bubble,
-.docs-gm .docs-multi-linkbubble-bubble {
-  background-color: var(--darkgray);
-  border: 1px solid var(--lightgray) !important;
+/* Spellcheck mini popup */
+.docs-autocorrect-bubble .docs-autocorrect-bubble-undo,
+.kix-spell-bubble .kix-spell-bubble-suggestion-text {
+  color: white;
 }
+.docs-gm .kix-spell-bubble-option {
+  border-radius: 50%;
+  transition: var(--button-off);
+}
+
+/* Link popup */
 #docs-linkbubble-link-text {
   color: var(--paleblue) !important;
-}
-.docs-bubble .docs-bubble-button.jfk-button:hover, 
-.docs-bubble .docs-bubble-button.jfk-button:focus {
-  background-color: var(--gray);
-  transition: var(--button-on);
 }
 /* Link popup footer that prompts to replace the link */
 .docs-linkbubble-link-preview .docs-link-bubble-card-component.docs-link-bubble-action-card-component, 

--- a/dark-docs.css
+++ b/dark-docs.css
@@ -257,7 +257,7 @@
   filter: brightness(10);
 }
 .docs-gm .docs-material .goog-toolbar-button-checked {
-  background-color: var(--ripple);
+  background-color: var(--ripple) !important;
 }
 .docs-gm .docs-material .goog-toolbar-button-checked .docs-icon-img {
   filter: var(--pale-icons) !important;
@@ -402,6 +402,7 @@ body {
 /* Popups */
 
 /* Box */
+.kix-embedded-entity-bubble.docs-bubble,
 .docs-gm .kix-spell-bubble, 
 .docs-autocorrect-bubble,
 .docs-gm .docs-linkbubble-bubble, 

--- a/dark-docs.css
+++ b/dark-docs.css
@@ -400,10 +400,11 @@ body {
 }
 
 /* Spellcheck mini popup */
-.docs-gm .kix-spell-bubble {
+.docs-gm .kix-spell-bubble, .docs-autocorrect-bubble {
   background-color: var(--darkgray);
   border-color: var(--gray);
 }
+.docs-autocorrect-bubble .docs-autocorrect-bubble-undo,
 .kix-spell-bubble .kix-spell-bubble-suggestion-text {
   color: white;
 }
@@ -411,6 +412,10 @@ body {
   border-radius: 50%;
   transition: var(--button-off);
 }
+.docs-gm .docs-autocorrect-bubble-more-options:hover,
+.docs-gm .docs-autocorrect-bubble-more-options:focus,
+.docs-gm .docs-autocorrect-bubble-undo:hover,
+.docs-gm .kix-spell-bubble-suggestion-text:hover,
 .docs-gm .kix-spell-bubble-option:hover {
   background-color: var(--gray);
   transition: var(--button-on);

--- a/dark-docs.css
+++ b/dark-docs.css
@@ -402,7 +402,7 @@ body {
 /* Spellcheck mini popup */
 .docs-gm .kix-spell-bubble, .docs-autocorrect-bubble {
   background-color: var(--darkgray);
-  border-color: var(--gray);
+  border: 1px solid var(--lightgray) !important;
 }
 .docs-autocorrect-bubble .docs-autocorrect-bubble-undo,
 .kix-spell-bubble .kix-spell-bubble-suggestion-text {


### PR DESCRIPTION
Styles for the following popups were added/improved on:
- Spellcheck* (d65a2f1c50e9a9b023aae9a342915f2a8fc5302f) (*the actual styles were not changed, but more selectors were added)
- Links (920016dca877d067178ba1a9e1e1a48c11427ea0)
- Images (d65a2f1c50e9a9b023aae9a342915f2a8fc5302f)

Popup styles were also generalized. 

Some points of concern:
- Two blacker/more transparent dark blues were directly hardcoded in 920016dca877d067178ba1a9e1e1a48c11427ea0. Of course, preferably variables and colours in or closer to the mobile Google Docs standard would be used. 
- The selectors for popup options ([diff](https://github.com/winghongchan/dark-docs/commit/4901dfd5d958aa34d60eae3e91fe967d7e487a2d#diff-1cd17ed4475ec79165605a41f3627911c98c4e32e3d80d11c851d7b50975c4a3R414-R418)) are not generalized and are still specific to e.g. spellcheck popups, links, etc. However, the styles are the same. Would it be preferable to group styles together (at the cost of what is seen in the diff), group all component of a style together (at the cost of repeating code for the same styles), or something else?


